### PR TITLE
fix: client themes not correctly applying

### DIFF
--- a/src/Components/Settings.tsx
+++ b/src/Components/Settings.tsx
@@ -1,5 +1,4 @@
 import { util } from "replugged";
-import { users as UltimateUserStore } from "replugged/common";
 import { Divider, FormText, SelectItem, SwitchItem } from "replugged/components";
 import { PluginLogger, SettingValues } from "../index";
 import { defaultSettings } from "../lib/consts";

--- a/src/lib/requiredModules.ts
+++ b/src/lib/requiredModules.ts
@@ -86,7 +86,9 @@ Modules.loadModules = async (): Promise<void> => {
     });
 
   Modules.GradientPresets ??= {
-    BACKGROUND_GRADIENT_PRESETS_MAP: webpack.getExportsForProps(Modules.GradientPresetsModule, [0]),
+    BACKGROUND_GRADIENT_PRESETS_MAP: Object.values(Modules.GradientPresetsModule).find(
+      (x) => !Array.isArray(x),
+    ),
   };
 
   Modules.FolderConstructor ??= await webpack

--- a/src/plaintextFunctions.tsx
+++ b/src/plaintextFunctions.tsx
@@ -1,4 +1,4 @@
-import { SettingValues, PluginLogger } from "./index";
+import { PluginLogger, SettingValues } from "./index";
 import { defaultSettings } from "./lib/consts";
 export const _getGradientPreset = (preset: string): string => {
   return SettingValues.get("gradientPreset", defaultSettings.gradientPreset) ?? preset;


### PR DESCRIPTION
Fixes an issue with client themes where the selected theme was not correctly applied.
The problem was that the wrong property from the gradients module was obtained, getting instead an unordered array. The solution is to get the other property, an object sorted by theme id.

You can test it by selecting the latest themes in the list (e.g. Sepia).